### PR TITLE
Prepare v0.0.1-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "squire"
-version = "0.0.1-alpha.3"
+version = "0.0.1-alpha.4"
 dependencies = [
  "fallible-iterator",
  "serde_json",
@@ -500,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "squire-sqlite3-src"
-version = "3.50.4-alpha.2"
+version = "3.51.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81033c46efc2041476ebb65c624218346a91efbfd4a11dc65c67dc7cc350f52d"
+checksum = "81494723359a518f52c0dfab12bab2e8af7d02875d9013b9448e97199a0db576"
 dependencies = [
  "cc",
  "strum",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "squire-sqlite3-sys"
-version = "0.0.1-alpha.3"
+version = "0.0.1-alpha.4"
 dependencies = [
  "bindgen",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squire"
-version = "0.0.1-alpha.3"
+version = "0.0.1-alpha.4"
 edition = "2024"
 description = "Safe and idiomatic SQLite bindings"
 readme = "Readme.md"
@@ -81,7 +81,7 @@ default-features = false
 [dependencies.sqlite]
 package = "squire-sqlite3-sys"
 path = "crates/sys"
-version = "0.0.1-alpha.3"
+version = "0.0.1-alpha.4"
 default-features = false
 
 [dependencies.fallible-iterator]

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,8 @@ Squire is a [crate][] for embedding [SQLite][] in Rust. It provides a safe, idio
 [SQLite]: https://sqlite.org/
 [C API]: https://sqlite.org/cintro.html
 
+> ⚠️ Squire is under active development, without even a `0.0.1` release yet. Not all features describe below exist.
+
 ```rust
 use squire::{Connection, Database};
 
@@ -36,13 +38,6 @@ pub struct User {
     pub id: squire::RowId,
     pub username: String,
     pub score: f64,
-}
-
-project!(User { id, username, })
-
-select! {
-    User {
-    }
 }
 
 #[derive(squire::Bind)]

--- a/crates/sys/Cargo.toml
+++ b/crates/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "squire-sqlite3-sys"
 description = "External FFI bindings for the SQLite C API"
-version = "0.0.1-alpha.3"
+version = "0.0.1-alpha.4"
 edition = "2024"
 links = "sqlite3"
 readme = "Readme.md"
@@ -92,7 +92,7 @@ wal = []
 [build-dependencies.sqlite]
 package = "squire-sqlite3-src"
 # path = "../../../ext/squire-src"
-version = "3.50.4-alpha.2"
+version = "3.51.0-alpha.2"
 optional = true
 
 [build-dependencies.bindgen]


### PR DESCRIPTION
Update bundled SQLite to v3.51, and publish a new alpha release of `squire` and `squire-sqlite3-sys`. Include `squire-derive` for the first time.