### PR TITLE
Release v0.0.1-alpha.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Run linter
         run: >-
           cargo clippy --features full
+      - name: Run linter (all features)
+        run: >-
+          cargo clippy --all-features
 
   test:
     name: Test
@@ -74,17 +77,20 @@ jobs:
           channel: ${{ matrix.channel }}
       - name: Run tests (default features)
         run: >-
-          cargo test --no-default-features --features '${{ matrix.sqlite }} common derive multi-thread'
+          cargo test --no-default-features --features '${{ matrix.sqlite != 'linked' && matrix.sqlite || '' }} common derive multi-thread'
       - name: Run tests (full features)
         run: >-
-          cargo test --no-default-features --features '${{ matrix.sqlite }} full derive multi-thread'
+          cargo test --no-default-features --features '${{ matrix.sqlite != 'linked' && matrix.sqlite || '' }} full derive multi-thread'
       - name: Run tests (full features + integrations)
         run: >-
-          cargo test --no-default-features --features '${{ matrix.sqlite }} complete derive multi-thread'
+          cargo test --no-default-features --features '${{ matrix.sqlite != 'linked' && matrix.sqlite || '' }} complete derive multi-thread'
       - name: Run tests (full + nightly features)
         run: >-
-          cargo test --no-default-features --features '${{ matrix.sqlite }} full derive multi-thread nightly'
-        if: matrix.channel == 'nightly'
+          cargo test --no-default-features --features '${{ matrix.sqlite != 'linked' && matrix.sqlite || '' }} full derive multi-thread nightly'
+      - name: Run tests (all features)
+        run: >-
+          cargo test --all-features
+        if: matrix.channel != 'linked'
       - name: Run tests (minimal features)
         run: >-
-          cargo test --no-default-features --features '${{ matrix.sqlite }} single-thread' -- --test-threads=1
+          cargo test --no-default-features --features '${{ matrix.sqlite != 'linked' && matrix.sqlite || '' }}' -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "squire"
-version = "0.0.1-alpha.4"
+version = "0.0.1-alpha.5"
 dependencies = [
  "jiff",
  "rustversion",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "squire-derive"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "squire-sqlite3-features"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "cc",
  "inherent",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "squire-sqlite3-sys"
-version = "0.0.1-alpha.4"
+version = "0.0.1-alpha.5"
 dependencies = [
  "bindgen",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +578,7 @@ name = "squire"
 version = "0.0.1-alpha.4"
 dependencies = [
  "jiff",
+ "rustversion",
  "serde",
  "squire-derive",
  "squire-serde",
@@ -588,6 +595,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squire"
-version = "0.0.1-alpha.4"
+version = "0.0.1-alpha.5"
 edition = "2024"
 description = "Safe and idiomatic SQLite bindings"
 readme = "Readme.md"
@@ -81,7 +81,7 @@ rustversion = ["dep:rustversion"]
 
 [dependencies.squire-derive]
 path = "crates/derive"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 optional = true
 default-features = false
 
@@ -93,7 +93,7 @@ optional = true
 [dependencies.sqlite]
 package = "squire-sqlite3-sys"
 path = "crates/sys"
-version = "0.0.1-alpha.4"
+version = "0.0.1-alpha.5"
 default-features = false
 
 [dependencies.jiff]
@@ -111,7 +111,7 @@ optional = true
 [build-dependencies.features]
 package = "squire-sqlite3-features"
 path = "crates/features"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 features = ["metadata"]
 
 [build-dependencies.rustversion]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ widestring = ["utf-16", "dep:widestring"]
 
 nightly = ["lang-array-assume-init", "lang-rustc-scalar-valid-range", "lang-step-trait"]
 lang-array-assume-init = ["rustversion", "squire-derive?/lang-array-assume-init"]
-lang-iat = ["rustversion"]
 lang-rustc-scalar-valid-range = ["rustversion"]
 lang-step-trait = ["rustversion"]
 rustversion = ["dep:rustversion"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,11 @@ members = ["crates/derive", "crates/features", "crates/serde", "crates/sys"]
 repository = "https://github.com/silverlyra/squire"
 license = "Apache-2.0"
 
+[workspace.dependencies.rustversion]
+version = "1.0"
+
 [features]
-default = ["linked", "common", "derive", "multi-thread"]
+default = ["common", "derive", "multi-thread"]
 derive = ["dep:squire-derive"]
 
 common = ["sqlite/common", "json", "mutex"]
@@ -26,12 +29,11 @@ full = ["sqlite/full", "common"]
 complete = ["full", "integrations"]
 
 bundled = ["sqlite/bundled"]
-linked = ["sqlite/linked"]
+bindgen = ["sqlite/bindgen"]
 static = ["sqlite/static"]
 
-single-thread = ["sqlite/single-thread"]
 multi-thread = ["sqlite/multi-thread"]
-serialized = ["sqlite/serialized", "mutex"]
+serialized = ["multi-thread", "sqlite/serialized", "mutex"]
 
 armor = ["sqlite/armor"]
 authorization = ["sqlite/authorization"]
@@ -71,10 +73,11 @@ url = ["dep:url"]
 widestring = ["utf-16", "dep:widestring"]
 
 nightly = ["lang-array-assume-init", "lang-rustc-scalar-valid-range", "lang-step-trait"]
-lang-array-assume-init = ["squire-derive?/lang-array-assume-init"]
-lang-iat = []
-lang-rustc-scalar-valid-range = []
-lang-step-trait = []
+lang-array-assume-init = ["rustversion", "squire-derive?/lang-array-assume-init"]
+lang-iat = ["rustversion"]
+lang-rustc-scalar-valid-range = ["rustversion"]
+lang-step-trait = ["rustversion"]
+rustversion = ["dep:rustversion"]
 
 [dependencies.squire-derive]
 path = "crates/derive"
@@ -110,6 +113,10 @@ package = "squire-sqlite3-features"
 path = "crates/features"
 version = "0.0.1-alpha.1"
 features = ["metadata"]
+
+[build-dependencies.rustversion]
+workspace = true
+optional = true
 
 [dev-dependencies.serde]
 version = "^1.0.220"

--- a/build.rs
+++ b/build.rs
@@ -4,8 +4,52 @@ fn main() -> Result {
     // Read feature detection from the sys crate's build script
     let library = features::Library::from_cargo_metadata()?;
 
-    // Emit the same cfg attributes
+    // Verify threading mode compatibility
+    check_threading_mode(&library);
+
+    // Emit cfg attributes for SQLite feature detection
     library.emit_cfg();
 
+    // Emit `nightly` cfg when compiling on a nightly/dev toolchain, so that
+    // `--all-features` (including `nightly` and `lang-*` features) can be used
+    // on a stable or beta toolchain.
+    emit_nightly_cfg();
+
     Ok(())
+}
+
+fn emit_nightly_cfg() {
+    println!("cargo::rustc-check-cfg=cfg(nightly)");
+
+    #[cfg(feature = "rustversion")]
+    if rustversion::cfg!(nightly) {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}
+
+/// Check that the SQLite library's threading mode is compatible with the
+/// requested features.
+///
+/// The `multi-thread` feature (which `serialized` implies) requires SQLite
+/// built with SQLITE_THREADSAFE=1 or 2. If the library is single-threaded,
+/// we fail the build.
+///
+/// Note: We don't require serialized mode even when the `serialized` feature
+/// is enabled, because we pass `SQLITE_OPEN_FULLMUTEX` at connection open time
+/// to upgrade multi-thread mode to serialized behavior.
+fn check_threading_mode(library: &features::Library) {
+    use features::Threading;
+
+    #[allow(unused_variables)]
+    let actual = library.threading();
+
+    #[cfg(feature = "multi-thread")]
+    {
+        if actual == Threading::SingleThread {
+            panic!(
+                "multi-thread feature enabled, but SQLite was built with \
+                SQLITE_THREADSAFE=0, and can only be used single-threaded"
+            );
+        }
+    }
 }

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -10,7 +10,8 @@ keywords = ["sqlite", "database", "derive", "proc_macro"]
 
 [features]
 nightly = ["lang-array-assume-init"]
-lang-array-assume-init = []
+lang-array-assume-init = ["rustversion"]
+rustversion = ["dep:rustversion"]
 
 [lib]
 proc-macro = true
@@ -26,3 +27,7 @@ version = "^1.0.40"
 
 [dependencies.syn]
 version = "^2.0.100"
+
+[dependencies.rustversion]
+workspace = true
+optional = true

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "squire-derive"
 description = "Procedural macros for Squire"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 edition = "2024"
 repository.workspace = true
 license.workspace = true

--- a/crates/derive/src/common.rs
+++ b/crates/derive/src/common.rs
@@ -262,7 +262,7 @@ impl NamedIndexResolution {
     ) -> Self {
         let count = names.len();
 
-        let initializers = names.keys().enumerate().map(|(i, name)| {
+        let initializers = names.iter().map(|(name, i)| {
             quote! {
                 if let Some(index) = #which.index(#name) {
                     indexes[#i].write(index);

--- a/crates/features/Cargo.toml
+++ b/crates/features/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "squire-sqlite3-features"
 description = "Detect available features and options in a copy of SQLite"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 edition = "2024"
 readme = "Readme.md"
 repository.workspace = true

--- a/crates/features/src/lib.rs
+++ b/crates/features/src/lib.rs
@@ -120,6 +120,9 @@ impl Library {
             let name = key.as_str();
             println!("cargo:rustc-cfg=sqlite_has_{name}");
         }
+
+        // Include SQLite library version
+        println!("cargo::rustc-env=SQUIRE_SQLITE_VERSION={}", self.version());
     }
 
     #[cfg(feature = "metadata")]

--- a/crates/features/src/version.rs
+++ b/crates/features/src/version.rs
@@ -38,7 +38,7 @@ impl Version {
         }
     }
 
-    /// Create a [`Version`] from `major`.`minor`.`0.`
+    /// Create a [`Version`] from `major`.`minor`.`0`.
     #[inline]
     pub const fn release(major: usize, minor: usize) -> Self {
         Self::new(major, minor, 0)

--- a/crates/sys/Cargo.toml
+++ b/crates/sys/Cargo.toml
@@ -19,8 +19,7 @@ bindgen = [
     "dep:proc-macro2",
     "dep:quote",
 ]
-bundled = ["dep:sqlite", "bindgen", "static"]
-linked = ["bindgen", "features/build"]
+bundled = ["dep:sqlite", "static"]
 static = []
 
 multi-thread = []

--- a/crates/sys/Cargo.toml
+++ b/crates/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "squire-sqlite3-sys"
 description = "External FFI bindings for the SQLite C API"
-version = "0.0.1-alpha.4"
+version = "0.0.1-alpha.5"
 edition = "2024"
 links = "sqlite3"
 readme = "Readme.md"
@@ -121,7 +121,7 @@ optional = true
 [build-dependencies.features]
 package = "squire-sqlite3-features"
 path = "../features"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 features = ["inherent", "metadata", "build"]
 
 [package.metadata.docs.rs]

--- a/crates/sys/Cargo.toml
+++ b/crates/sys/Cargo.toml
@@ -23,9 +23,8 @@ bundled = ["dep:sqlite", "bindgen", "static"]
 linked = ["bindgen", "features/build"]
 static = []
 
-single-thread = []
 multi-thread = []
-serialized = []
+serialized = ["multi-thread"]
 
 core = [
     "json",
@@ -124,7 +123,7 @@ optional = true
 package = "squire-sqlite3-features"
 path = "../features"
 version = "0.0.1-alpha.1"
-features = ["inherent", "metadata"]
+features = ["inherent", "metadata", "build"]
 
 [package.metadata.docs.rs]
 features = ["bundled", "full", "serialized"]

--- a/crates/sys/Readme.md
+++ b/crates/sys/Readme.md
@@ -7,3 +7,12 @@ Users of Squire don't need to interact with this crate directly, and can treat i
 [Squire]: https://lib.rs/squire
 [SQLite]: https://sqlite.org/
 [C API]: https://sqlite.org/cintro.html
+
+## External Users
+
+By default, `squire-sqlite3-sys` ships a [predefined set][default] of `extern "C"` declarations for SQLite. This includes only the API’s actually used by Squire.
+
+To instead generate complete bindings based on the installed or bundled `sqlite3.h` header, activate the [`bindgen`][bindgen] feature.
+
+[default]: https://github.com/silverlyra/squire/blob/main/crates/sys/src/bindings/default/mod.rs
+[bindgen]: https://lib.rs/bindgen

--- a/crates/sys/build.rs
+++ b/crates/sys/build.rs
@@ -1,17 +1,20 @@
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
-
-#[cfg(not(feature = "bindgen"))]
-compile_error!("no SQLite bindings available: feature \"bindgen\" must be enabled");
+#[cfg(any(feature = "bindgen", feature = "bundled"))]
+use std::env;
+#[cfg(feature = "bundled")]
+use std::path::Path;
+#[cfg(any(feature = "bindgen", feature = "bundled"))]
+use std::path::PathBuf;
 
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn main() -> Result {
+    #[cfg(any(feature = "bindgen", feature = "bundled"))]
     let dest = out_path();
 
-    #[cfg(feature = "bundled")]
+    #[cfg(all(not(feature = "bindgen"), feature = "bundled"))]
+    build_bundled_sqlite(&dest)?;
+
+    #[cfg(all(feature = "bindgen", feature = "bundled"))]
     let header_path = {
         let build = build_bundled_sqlite(&dest)?;
         build.header()
@@ -69,6 +72,7 @@ fn bundled_features() -> impl Iterator<Item = features::FeatureKey> {
         .filter_map(|(key, enabled)| if enabled { Some(key) } else { None })
 }
 
+#[cfg(any(feature = "bindgen", feature = "bundled"))]
 fn out_path() -> PathBuf {
     env::var_os("OUT_DIR")
         .expect("cargo did not set $OUT_DIR")
@@ -308,53 +312,7 @@ fn generate_bindings(header: &Path, dest: &Path) -> Result {
     let mut modified_bindings = prettyplease::unparse(&syntax_tree);
 
     // Add our custom union type definition at the end
-    modified_bindings.push_str(
-        r#"
-/// A destructor / memory `free` function for a value passed to SQLite as a
-/// [bound parameter][bind] or a [function result][].
-///
-/// A destructor can either be a `func`tion, or one of the [special values][]
-/// `SQLITE_STATIC` (`0`) or `SQLITE_TRANSIENT` (`-1`).
-///
-/// [bind]: https://sqlite.org/c3ref/bind_blob.html
-/// [function result]: https://sqlite.org/c3ref/result_blob.html
-/// [special values]: https://sqlite.org/c3ref/c_static.html
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union sqlite3_destructor_type {
-    pub func: unsafe extern "C" fn(context: *mut ::std::os::raw::c_void),
-    pub sentinel: isize,
-}
-
-// Safety: The union only contains POD types
-unsafe impl Send for sqlite3_destructor_type {}
-unsafe impl Sync for sqlite3_destructor_type {}
-
-impl sqlite3_destructor_type {
-    /// Provide a custom [destructor](sqlite3_destructor_type) to SQLite.
-    pub const fn new(func: unsafe extern "C" fn(*mut ::std::os::raw::c_void)) -> Self {
-        sqlite3_destructor_type { func }
-    }
-
-    /// Construct `SQLITE_STATIC` or `SQLITE_TRANSIENT`.
-    pub(crate) const fn from_sentinel(sentinel: isize) -> Self {
-        sqlite3_destructor_type { sentinel }
-    }
-}
-
-impl ::core::fmt::Debug for sqlite3_destructor_type {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        // Safety: Both fields have the same size, so reading sentinel is always valid
-        let sentinel = unsafe { self.sentinel };
-        match sentinel {
-            0 => write!(f, "sqlite3_destructor_type::SQLITE_STATIC"),
-            -1 => write!(f, "sqlite3_destructor_type::SQLITE_TRANSIENT"),
-            _ => write!(f, "sqlite3_destructor_type::func({:p})", sentinel as *const ()),
-        }
-    }
-}
-"#,
-    );
+    modified_bindings.push_str(include_str!("src/bindings/destructor.rs"));
 
     std::fs::write(dest, modified_bindings)?;
 

--- a/crates/sys/src/bindings/default/column.rs
+++ b/crates/sys/src/bindings/default/column.rs
@@ -1,0 +1,14 @@
+use core::ffi::{c_int, c_uchar, c_void};
+
+use super::{statement::sqlite3_stmt, types::sqlite3_int64, value::sqlite3_value};
+
+unsafe extern "C" {
+    pub fn sqlite3_column_blob(pStmt: *mut sqlite3_stmt, iCol: c_int) -> *const c_void;
+    pub fn sqlite3_column_double(pStmt: *mut sqlite3_stmt, iCol: c_int) -> f64;
+    pub fn sqlite3_column_int(pStmt: *mut sqlite3_stmt, iCol: c_int) -> c_int;
+    pub fn sqlite3_column_int64(pStmt: *mut sqlite3_stmt, iCol: c_int) -> sqlite3_int64;
+    pub fn sqlite3_column_text(pStmt: *mut sqlite3_stmt, iCol: c_int) -> *const c_uchar;
+    pub fn sqlite3_column_value(pStmt: *mut sqlite3_stmt, iCol: c_int) -> *mut sqlite3_value;
+    pub fn sqlite3_column_bytes(pStmt: *mut sqlite3_stmt, iCol: c_int) -> c_int;
+    pub fn sqlite3_column_type(pStmt: *mut sqlite3_stmt, iCol: c_int) -> c_int;
+}

--- a/crates/sys/src/bindings/default/connection.rs
+++ b/crates/sys/src/bindings/default/connection.rs
@@ -1,0 +1,51 @@
+use core::ffi::{c_char, c_int};
+
+/// A database [connection handle][].
+///
+/// [connection handle]: https://sqlite.org/c3ref/sqlite3.html
+#[repr(C)]
+pub struct sqlite3 {
+    _unused: [u8; 0],
+}
+
+unsafe extern "C" {
+    /// [Open][open] a [database connection][].
+    ///
+    /// [open]: https://sqlite.org/c3ref/open.html
+    /// [database connection]: https://sqlite.org/c3ref/sqlite3.html
+    pub fn sqlite3_open_v2(
+        filename: *const c_char,
+        ppDb: *mut *mut sqlite3,
+        flags: c_int,
+        zVfs: *const c_char,
+    ) -> c_int;
+
+    /// [Close][close] a [database connection][].
+    ///
+    /// [close]: https://sqlite.org/c3ref/close.html
+    /// [database connection]: https://sqlite.org/c3ref/sqlite3.html
+    pub fn sqlite3_close(pDb: *mut sqlite3) -> c_int;
+}
+
+pub const SQLITE_OPEN_READONLY: i32 = 0x00000001;
+pub const SQLITE_OPEN_READWRITE: i32 = 0x00000002;
+pub const SQLITE_OPEN_CREATE: i32 = 0x00000004;
+pub const SQLITE_OPEN_DELETEONCLOSE: i32 = 0x00000008;
+pub const SQLITE_OPEN_EXCLUSIVE: i32 = 0x00000010;
+pub const SQLITE_OPEN_AUTOPROXY: i32 = 0x00000020;
+pub const SQLITE_OPEN_URI: i32 = 0x00000040;
+pub const SQLITE_OPEN_MEMORY: i32 = 0x00000080;
+pub const SQLITE_OPEN_MAIN_DB: i32 = 0x00000100;
+pub const SQLITE_OPEN_TEMP_DB: i32 = 0x00000200;
+pub const SQLITE_OPEN_TRANSIENT_DB: i32 = 0x00000400;
+pub const SQLITE_OPEN_MAIN_JOURNAL: i32 = 0x00000800;
+pub const SQLITE_OPEN_TEMP_JOURNAL: i32 = 0x00001000;
+pub const SQLITE_OPEN_SUBJOURNAL: i32 = 0x00002000;
+pub const SQLITE_OPEN_SUPER_JOURNAL: i32 = 0x00004000;
+pub const SQLITE_OPEN_NOMUTEX: i32 = 0x00008000;
+pub const SQLITE_OPEN_FULLMUTEX: i32 = 0x00010000;
+pub const SQLITE_OPEN_SHAREDCACHE: i32 = 0x00020000;
+pub const SQLITE_OPEN_PRIVATECACHE: i32 = 0x00040000;
+pub const SQLITE_OPEN_WAL: i32 = 0x00080000;
+pub const SQLITE_OPEN_NOFOLLOW: i32 = 0x01000000;
+pub const SQLITE_OPEN_EXRESCODE: i32 = 0x02000000;

--- a/crates/sys/src/bindings/default/memory.rs
+++ b/crates/sys/src/bindings/default/memory.rs
@@ -1,0 +1,14 @@
+use core::ffi::{c_int, c_void};
+
+use super::types::{sqlite3_int64, sqlite3_uint64};
+
+unsafe extern "C" {
+    pub fn sqlite3_malloc(size: c_int) -> *mut c_void;
+    pub fn sqlite3_malloc64(size: sqlite3_uint64) -> *mut c_void;
+    pub fn sqlite3_realloc(ptr: *mut c_void, size: c_int) -> *mut c_void;
+    pub fn sqlite3_realloc64(ptr: *mut c_void, size: sqlite3_uint64) -> *mut c_void;
+    pub fn sqlite3_free(ptr: *mut c_void);
+    pub fn sqlite3_msize(ptr: *mut c_void) -> sqlite3_uint64;
+    pub fn sqlite3_memory_used() -> sqlite3_int64;
+    pub fn sqlite3_memory_highwater(resetFlag: c_int) -> sqlite3_int64;
+}

--- a/crates/sys/src/bindings/default/mod.rs
+++ b/crates/sys/src/bindings/default/mod.rs
@@ -1,0 +1,25 @@
+mod column;
+mod connection;
+mod memory;
+mod mutex;
+mod param;
+mod result;
+mod statement;
+mod string;
+mod types;
+mod value;
+mod version;
+
+pub use column::*;
+pub use connection::*;
+pub use memory::*;
+pub use mutex::*;
+pub use param::*;
+pub use result::*;
+pub use statement::*;
+pub use string::*;
+pub use types::*;
+pub use value::*;
+pub use version::*;
+
+pub use super::destructor::sqlite3_destructor_type;

--- a/crates/sys/src/bindings/default/mutex.rs
+++ b/crates/sys/src/bindings/default/mutex.rs
@@ -1,0 +1,35 @@
+use core::ffi::c_int;
+
+use super::connection::sqlite3;
+
+#[repr(C)]
+pub struct sqlite3_mutex {
+    _unused: [u8; 0],
+}
+
+pub const SQLITE_MUTEX_FAST: i32 = 0;
+pub const SQLITE_MUTEX_RECURSIVE: i32 = 1;
+pub const SQLITE_MUTEX_STATIC_MAIN: i32 = 2;
+pub const SQLITE_MUTEX_STATIC_MEM: i32 = 3;
+pub const SQLITE_MUTEX_STATIC_MEM2: i32 = 4;
+pub const SQLITE_MUTEX_STATIC_OPEN: i32 = 4;
+pub const SQLITE_MUTEX_STATIC_PRNG: i32 = 5;
+pub const SQLITE_MUTEX_STATIC_LRU: i32 = 6;
+pub const SQLITE_MUTEX_STATIC_LRU2: i32 = 7;
+pub const SQLITE_MUTEX_STATIC_PMEM: i32 = 7;
+pub const SQLITE_MUTEX_STATIC_APP1: i32 = 8;
+pub const SQLITE_MUTEX_STATIC_APP2: i32 = 9;
+pub const SQLITE_MUTEX_STATIC_APP3: i32 = 10;
+pub const SQLITE_MUTEX_STATIC_VFS1: i32 = 11;
+pub const SQLITE_MUTEX_STATIC_VFS2: i32 = 12;
+pub const SQLITE_MUTEX_STATIC_VFS3: i32 = 13;
+pub const SQLITE_MUTEX_STATIC_MASTER: i32 = 2;
+
+unsafe extern "C" {
+    pub fn sqlite3_mutex_alloc(iMode: c_int) -> *mut sqlite3_mutex;
+    pub fn sqlite3_mutex_free(pMutex: *mut sqlite3_mutex);
+    pub fn sqlite3_mutex_enter(pMutex: *mut sqlite3_mutex);
+    pub fn sqlite3_mutex_try(pMutex: *mut sqlite3_mutex) -> c_int;
+    pub fn sqlite3_mutex_leave(pMutex: *mut sqlite3_mutex);
+    pub fn sqlite3_db_mutex(pDb: *mut sqlite3) -> *mut sqlite3_mutex;
+}

--- a/crates/sys/src/bindings/default/param.rs
+++ b/crates/sys/src/bindings/default/param.rs
@@ -1,0 +1,66 @@
+use core::ffi::{c_char, c_int, c_uchar, c_void};
+
+use super::{
+    sqlite3_destructor_type,
+    statement::sqlite3_stmt,
+    types::{sqlite3_int64, sqlite3_uint64},
+    value::sqlite3_value,
+};
+
+unsafe extern "C" {
+    pub fn sqlite3_bind_blob(
+        pStmt: *mut sqlite3_stmt,
+        parameter: c_int,
+        value: *const c_void,
+        len: c_int,
+        destructor: sqlite3_destructor_type,
+    ) -> c_int;
+    pub fn sqlite3_bind_blob64(
+        pStmt: *mut sqlite3_stmt,
+        parameter: c_int,
+        value: *const c_void,
+        len: sqlite3_uint64,
+        destructor: sqlite3_destructor_type,
+    ) -> c_int;
+    pub fn sqlite3_bind_double(pStmt: *mut sqlite3_stmt, parameter: c_int, arg3: f64) -> c_int;
+    pub fn sqlite3_bind_int(pStmt: *mut sqlite3_stmt, parameter: c_int, arg3: c_int) -> c_int;
+    pub fn sqlite3_bind_int64(
+        pStmt: *mut sqlite3_stmt,
+        parameter: c_int,
+        arg3: sqlite3_int64,
+    ) -> c_int;
+    pub fn sqlite3_bind_null(pStmt: *mut sqlite3_stmt, parameter: c_int) -> c_int;
+    pub fn sqlite3_bind_text(
+        pStmt: *mut sqlite3_stmt,
+        parameter: c_int,
+        value: *const c_char,
+        len: c_int,
+        destructor: sqlite3_destructor_type,
+    ) -> c_int;
+    pub fn sqlite3_bind_text64(
+        pStmt: *mut sqlite3_stmt,
+        parameter: c_int,
+        value: *const c_char,
+        len: sqlite3_uint64,
+        destructor: sqlite3_destructor_type,
+        encoding: c_uchar,
+    ) -> c_int;
+    pub fn sqlite3_bind_value(
+        pStmt: *mut sqlite3_stmt,
+        parameter: c_int,
+        value: *const sqlite3_value,
+    ) -> c_int;
+    pub fn sqlite3_bind_pointer(
+        pStmt: *mut sqlite3_stmt,
+        parameter: c_int,
+        value: *mut c_void,
+        type_name: *const c_char,
+        destructor: sqlite3_destructor_type,
+    ) -> c_int;
+    pub fn sqlite3_bind_zeroblob(pStmt: *mut sqlite3_stmt, parameter: c_int, n: c_int) -> c_int;
+    pub fn sqlite3_bind_zeroblob64(
+        pStmt: *mut sqlite3_stmt,
+        parameter: c_int,
+        arg3: sqlite3_uint64,
+    ) -> c_int;
+}

--- a/crates/sys/src/bindings/default/result.rs
+++ b/crates/sys/src/bindings/default/result.rs
@@ -1,0 +1,158 @@
+use core::ffi::{c_char, c_int};
+
+use super::connection::sqlite3;
+
+/// Successful result
+pub const SQLITE_OK: i32 = 0;
+/// Generic error
+pub const SQLITE_ERROR: i32 = 1;
+/// Internal logic error in SQLite
+pub const SQLITE_INTERNAL: i32 = 2;
+/// Access permission denied
+pub const SQLITE_PERM: i32 = 3;
+/// Callback routine requested an abort
+pub const SQLITE_ABORT: i32 = 4;
+/// The database file is locked
+pub const SQLITE_BUSY: i32 = 5;
+/// A table in the database is locked
+pub const SQLITE_LOCKED: i32 = 6;
+/// A malloc() failed
+pub const SQLITE_NOMEM: i32 = 7;
+/// Attempt to write a readonly database
+pub const SQLITE_READONLY: i32 = 8;
+/// Operation terminated by sqlite3_interrupt()
+pub const SQLITE_INTERRUPT: i32 = 9;
+/// Some kind of disk I/O error occurred
+pub const SQLITE_IOERR: i32 = 10;
+/// The database disk image is malformed
+pub const SQLITE_CORRUPT: i32 = 11;
+/// Unknown opcode in sqlite3_file_control()
+pub const SQLITE_NOTFOUND: i32 = 12;
+/// Insertion failed because database is full
+pub const SQLITE_FULL: i32 = 13;
+/// Unable to open the database file
+pub const SQLITE_CANTOPEN: i32 = 14;
+/// Database lock protocol error
+pub const SQLITE_PROTOCOL: i32 = 15;
+/// Internal use only
+pub const SQLITE_EMPTY: i32 = 16;
+/// The database schema changed
+pub const SQLITE_SCHEMA: i32 = 17;
+/// String or BLOB exceeds size limit
+pub const SQLITE_TOOBIG: i32 = 18;
+/// Abort due to constraint violation
+pub const SQLITE_CONSTRAINT: i32 = 19;
+/// Data type mismatch
+pub const SQLITE_MISMATCH: i32 = 20;
+/// Library used incorrectly
+pub const SQLITE_MISUSE: i32 = 21;
+/// Uses OS features not supported on host
+pub const SQLITE_NOLFS: i32 = 22;
+/// Authorization denied
+pub const SQLITE_AUTH: i32 = 23;
+/// Not used
+pub const SQLITE_FORMAT: i32 = 24;
+/// 2nd parameter to sqlite3_bind out of range
+pub const SQLITE_RANGE: i32 = 25;
+/// File opened that is not a database file
+pub const SQLITE_NOTADB: i32 = 26;
+/// Notifications from sqlite3_log()
+pub const SQLITE_NOTICE: i32 = 27;
+/// Warnings from sqlite3_log()
+pub const SQLITE_WARNING: i32 = 28;
+/// sqlite3_step() has another row ready
+pub const SQLITE_ROW: i32 = 100;
+/// sqlite3_step() has finished executing
+pub const SQLITE_DONE: i32 = 101;
+
+pub const SQLITE_ERROR_MISSING_COLLSEQ: i32 = SQLITE_ERROR | 1 << 8;
+pub const SQLITE_ERROR_RETRY: i32 = SQLITE_ERROR | 2 << 8;
+pub const SQLITE_ERROR_SNAPSHOT: i32 = SQLITE_ERROR | 3 << 8;
+pub const SQLITE_ERROR_RESERVESIZE: i32 = SQLITE_ERROR | 4 << 8;
+pub const SQLITE_ERROR_KEY: i32 = SQLITE_ERROR | 5 << 8;
+pub const SQLITE_ERROR_UNABLE: i32 = SQLITE_ERROR | 6 << 8;
+pub const SQLITE_IOERR_READ: i32 = SQLITE_IOERR | 1 << 8;
+pub const SQLITE_IOERR_SHORT_READ: i32 = SQLITE_IOERR | 2 << 8;
+pub const SQLITE_IOERR_WRITE: i32 = SQLITE_IOERR | 3 << 8;
+pub const SQLITE_IOERR_FSYNC: i32 = SQLITE_IOERR | 4 << 8;
+pub const SQLITE_IOERR_DIR_FSYNC: i32 = SQLITE_IOERR | 5 << 8;
+pub const SQLITE_IOERR_TRUNCATE: i32 = SQLITE_IOERR | 6 << 8;
+pub const SQLITE_IOERR_FSTAT: i32 = SQLITE_IOERR | 7 << 8;
+pub const SQLITE_IOERR_UNLOCK: i32 = SQLITE_IOERR | 8 << 8;
+pub const SQLITE_IOERR_RDLOCK: i32 = SQLITE_IOERR | 9 << 8;
+pub const SQLITE_IOERR_DELETE: i32 = SQLITE_IOERR | 10 << 8;
+pub const SQLITE_IOERR_BLOCKED: i32 = SQLITE_IOERR | 11 << 8;
+pub const SQLITE_IOERR_NOMEM: i32 = SQLITE_IOERR | 12 << 8;
+pub const SQLITE_IOERR_ACCESS: i32 = SQLITE_IOERR | 13 << 8;
+pub const SQLITE_IOERR_CHECKRESERVEDLOCK: i32 = SQLITE_IOERR | 14 << 8;
+pub const SQLITE_IOERR_LOCK: i32 = SQLITE_IOERR | 15 << 8;
+pub const SQLITE_IOERR_CLOSE: i32 = SQLITE_IOERR | 16 << 8;
+pub const SQLITE_IOERR_DIR_CLOSE: i32 = SQLITE_IOERR | 17 << 8;
+pub const SQLITE_IOERR_SHMOPEN: i32 = SQLITE_IOERR | 18 << 8;
+pub const SQLITE_IOERR_SHMSIZE: i32 = SQLITE_IOERR | 19 << 8;
+pub const SQLITE_IOERR_SHMLOCK: i32 = SQLITE_IOERR | 20 << 8;
+pub const SQLITE_IOERR_SHMMAP: i32 = SQLITE_IOERR | 21 << 8;
+pub const SQLITE_IOERR_SEEK: i32 = SQLITE_IOERR | 22 << 8;
+pub const SQLITE_IOERR_DELETE_NOENT: i32 = SQLITE_IOERR | 23 << 8;
+pub const SQLITE_IOERR_MMAP: i32 = SQLITE_IOERR | 24 << 8;
+pub const SQLITE_IOERR_GETTEMPPATH: i32 = SQLITE_IOERR | 25 << 8;
+pub const SQLITE_IOERR_CONVPATH: i32 = SQLITE_IOERR | 26 << 8;
+pub const SQLITE_IOERR_VNODE: i32 = SQLITE_IOERR | 27 << 8;
+pub const SQLITE_IOERR_AUTH: i32 = SQLITE_IOERR | 28 << 8;
+pub const SQLITE_IOERR_BEGIN_ATOMIC: i32 = SQLITE_IOERR | 29 << 8;
+pub const SQLITE_IOERR_COMMIT_ATOMIC: i32 = SQLITE_IOERR | 30 << 8;
+pub const SQLITE_IOERR_ROLLBACK_ATOMIC: i32 = SQLITE_IOERR | 31 << 8;
+pub const SQLITE_IOERR_DATA: i32 = SQLITE_IOERR | 32 << 8;
+pub const SQLITE_IOERR_CORRUPTFS: i32 = SQLITE_IOERR | 33 << 8;
+pub const SQLITE_IOERR_IN_PAGE: i32 = SQLITE_IOERR | 34 << 8;
+pub const SQLITE_IOERR_BADKEY: i32 = SQLITE_IOERR | 35 << 8;
+pub const SQLITE_IOERR_CODEC: i32 = SQLITE_IOERR | 36 << 8;
+pub const SQLITE_LOCKED_SHAREDCACHE: i32 = SQLITE_LOCKED | 1 << 8;
+pub const SQLITE_LOCKED_VTAB: i32 = SQLITE_LOCKED | 2 << 8;
+pub const SQLITE_BUSY_RECOVERY: i32 = SQLITE_BUSY | 1 << 8;
+pub const SQLITE_BUSY_SNAPSHOT: i32 = SQLITE_BUSY | 2 << 8;
+pub const SQLITE_BUSY_TIMEOUT: i32 = SQLITE_BUSY | 3 << 8;
+pub const SQLITE_CANTOPEN_NOTEMPDIR: i32 = SQLITE_CANTOPEN | 1 << 8;
+pub const SQLITE_CANTOPEN_ISDIR: i32 = SQLITE_CANTOPEN | 2 << 8;
+pub const SQLITE_CANTOPEN_FULLPATH: i32 = SQLITE_CANTOPEN | 3 << 8;
+pub const SQLITE_CANTOPEN_CONVPATH: i32 = SQLITE_CANTOPEN | 4 << 8;
+pub const SQLITE_CANTOPEN_DIRTYWAL: i32 = SQLITE_CANTOPEN | 5 << 8; /* Not Used */
+pub const SQLITE_CANTOPEN_SYMLINK: i32 = SQLITE_CANTOPEN | 6 << 8;
+pub const SQLITE_CORRUPT_VTAB: i32 = SQLITE_CORRUPT | 1 << 8;
+pub const SQLITE_CORRUPT_SEQUENCE: i32 = SQLITE_CORRUPT | 2 << 8;
+pub const SQLITE_CORRUPT_INDEX: i32 = SQLITE_CORRUPT | 3 << 8;
+pub const SQLITE_READONLY_RECOVERY: i32 = SQLITE_READONLY | 1 << 8;
+pub const SQLITE_READONLY_CANTLOCK: i32 = SQLITE_READONLY | 2 << 8;
+pub const SQLITE_READONLY_ROLLBACK: i32 = SQLITE_READONLY | 3 << 8;
+pub const SQLITE_READONLY_DBMOVED: i32 = SQLITE_READONLY | 4 << 8;
+pub const SQLITE_READONLY_CANTINIT: i32 = SQLITE_READONLY | 5 << 8;
+pub const SQLITE_READONLY_DIRECTORY: i32 = SQLITE_READONLY | 6 << 8;
+pub const SQLITE_ABORT_ROLLBACK: i32 = SQLITE_ABORT | 2 << 8;
+pub const SQLITE_CONSTRAINT_CHECK: i32 = SQLITE_CONSTRAINT | 1 << 8;
+pub const SQLITE_CONSTRAINT_COMMITHOOK: i32 = SQLITE_CONSTRAINT | 2 << 8;
+pub const SQLITE_CONSTRAINT_FOREIGNKEY: i32 = SQLITE_CONSTRAINT | 3 << 8;
+pub const SQLITE_CONSTRAINT_FUNCTION: i32 = SQLITE_CONSTRAINT | 4 << 8;
+pub const SQLITE_CONSTRAINT_NOTNULL: i32 = SQLITE_CONSTRAINT | 5 << 8;
+pub const SQLITE_CONSTRAINT_PRIMARYKEY: i32 = SQLITE_CONSTRAINT | 6 << 8;
+pub const SQLITE_CONSTRAINT_TRIGGER: i32 = SQLITE_CONSTRAINT | 7 << 8;
+pub const SQLITE_CONSTRAINT_UNIQUE: i32 = SQLITE_CONSTRAINT | 8 << 8;
+pub const SQLITE_CONSTRAINT_VTAB: i32 = SQLITE_CONSTRAINT | 9 << 8;
+pub const SQLITE_CONSTRAINT_ROWID: i32 = SQLITE_CONSTRAINT | 10 << 8;
+pub const SQLITE_CONSTRAINT_PINNED: i32 = SQLITE_CONSTRAINT | 11 << 8;
+pub const SQLITE_CONSTRAINT_DATATYPE: i32 = SQLITE_CONSTRAINT | 12 << 8;
+pub const SQLITE_NOTICE_RECOVER_WAL: i32 = SQLITE_NOTICE | 1 << 8;
+pub const SQLITE_NOTICE_RECOVER_ROLLBACK: i32 = SQLITE_NOTICE | 2 << 8;
+pub const SQLITE_NOTICE_RBU: i32 = SQLITE_NOTICE | 3 << 8;
+pub const SQLITE_WARNING_AUTOINDEX: i32 = SQLITE_WARNING | 1 << 8;
+pub const SQLITE_AUTH_USER: i32 = SQLITE_AUTH | 1 << 8;
+pub const SQLITE_OK_LOAD_PERMANENTLY: i32 = SQLITE_OK | 1 << 8;
+pub const SQLITE_OK_SYMLINK: i32 = SQLITE_OK | 2 << 8;
+
+unsafe extern "C" {
+    pub fn sqlite3_errcode(db: *mut sqlite3) -> c_int;
+    pub fn sqlite3_extended_errcode(db: *mut sqlite3) -> c_int;
+    pub fn sqlite3_errmsg(arg1: *mut sqlite3) -> *const c_char;
+    pub fn sqlite3_errstr(arg1: c_int) -> *const c_char;
+    pub fn sqlite3_error_offset(db: *mut sqlite3) -> c_int;
+    pub fn sqlite3_set_errmsg(db: *mut sqlite3, errcode: c_int, zErrMsg: *const c_char) -> c_int;
+}

--- a/crates/sys/src/bindings/default/statement.rs
+++ b/crates/sys/src/bindings/default/statement.rs
@@ -1,0 +1,56 @@
+use core::ffi::{c_char, c_int, c_uint};
+
+use super::{connection::sqlite3, types::sqlite3_int64};
+
+/// A [prepared statement][].
+///
+/// [prepared statement]: https://sqlite.org/c3ref/stmt.html
+#[repr(C)]
+pub struct sqlite3_stmt {
+    _unused: [u8; 0],
+}
+
+unsafe extern "C" {
+    /// [Prepare][prepare] a SQL [statement][].
+    ///
+    /// [prepare]: https://sqlite.org/c3ref/prepare.html
+    /// [statement]: https://sqlite.org/c3ref/stmt.html
+    pub fn sqlite3_prepare_v3(
+        db: *mut sqlite3,
+        zSql: *const c_char,
+        nByte: c_int,
+        prepFlags: c_uint,
+        ppStmt: *mut *mut sqlite3_stmt,
+        pzTail: *mut *const c_char,
+    ) -> c_int;
+
+    pub fn sqlite3_step(pStmt: *mut sqlite3_stmt) -> c_int;
+
+    pub fn sqlite3_bind_parameter_count(pStmt: *mut sqlite3_stmt) -> c_int;
+    pub fn sqlite3_bind_parameter_name(pStmt: *mut sqlite3_stmt, arg2: c_int) -> *const c_char;
+    pub fn sqlite3_bind_parameter_index(pStmt: *mut sqlite3_stmt, zName: *const c_char) -> c_int;
+
+    pub fn sqlite3_column_count(pStmt: *mut sqlite3_stmt) -> c_int;
+    pub fn sqlite3_column_name(pStmt: *mut sqlite3_stmt, n: c_int) -> *const c_char;
+    pub fn sqlite3_column_database_name(pStmt: *mut sqlite3_stmt, n: c_int) -> *const c_char;
+    pub fn sqlite3_column_table_name(pStmt: *mut sqlite3_stmt, n: c_int) -> *const c_char;
+    pub fn sqlite3_column_origin_name(pStmt: *mut sqlite3_stmt, n: c_int) -> *const c_char;
+    pub fn sqlite3_column_decltype(pStmt: *mut sqlite3_stmt, n: c_int) -> *const c_char;
+    pub fn sqlite3_data_count(pStmt: *mut sqlite3_stmt) -> c_int;
+
+    pub fn sqlite3_db_handle(pStmt: *mut sqlite3_stmt) -> *mut sqlite3;
+
+    pub fn sqlite3_changes(pStmt: *mut sqlite3) -> c_int;
+    pub fn sqlite3_changes64(pStmt: *mut sqlite3) -> sqlite3_int64;
+    pub fn sqlite3_last_insert_rowid(pStmt: *mut sqlite3) -> sqlite3_int64;
+    pub fn sqlite3_set_last_insert_rowid(pStmt: *mut sqlite3, id: sqlite3_int64);
+
+    pub fn sqlite3_clear_bindings(pStmt: *mut sqlite3_stmt) -> c_int;
+    pub fn sqlite3_reset(pStmt: *mut sqlite3_stmt) -> c_int;
+    pub fn sqlite3_finalize(pStmt: *mut sqlite3_stmt) -> c_int;
+}
+
+pub const SQLITE_PREPARE_PERSISTENT: i32 = 1;
+pub const SQLITE_PREPARE_NORMALIZE: i32 = 2;
+pub const SQLITE_PREPARE_NO_VTAB: i32 = 4;
+pub const SQLITE_PREPARE_DONT_LOG: i32 = 16;

--- a/crates/sys/src/bindings/default/string.rs
+++ b/crates/sys/src/bindings/default/string.rs
@@ -1,0 +1,20 @@
+use core::ffi::{c_char, c_int};
+
+use super::connection::sqlite3;
+
+#[repr(C)]
+pub struct sqlite3_str {
+    _unused: [u8; 0],
+}
+
+unsafe extern "C" {
+    pub fn sqlite3_str_new(pStr: *mut sqlite3) -> *mut sqlite3_str;
+    pub fn sqlite3_str_finish(pStr: *mut sqlite3_str) -> *mut c_char;
+    pub fn sqlite3_str_append(pStr: *mut sqlite3_str, zIn: *const c_char, N: c_int);
+    pub fn sqlite3_str_appendall(pStr: *mut sqlite3_str, zIn: *const c_char);
+    pub fn sqlite3_str_appendchar(pStr: *mut sqlite3_str, N: c_int, C: c_char);
+    pub fn sqlite3_str_reset(pStr: *mut sqlite3_str);
+    pub fn sqlite3_str_errcode(pStr: *mut sqlite3_str) -> c_int;
+    pub fn sqlite3_str_length(pStr: *mut sqlite3_str) -> c_int;
+    pub fn sqlite3_str_value(pStr: *mut sqlite3_str) -> *mut c_char;
+}

--- a/crates/sys/src/bindings/default/types.rs
+++ b/crates/sys/src/bindings/default/types.rs
@@ -1,0 +1,17 @@
+use core::ffi::{c_longlong, c_ulonglong};
+
+pub type sqlite_int64 = c_longlong;
+pub type sqlite_uint64 = c_ulonglong;
+pub type sqlite3_int64 = sqlite_int64;
+pub type sqlite3_uint64 = sqlite_uint64;
+
+pub const SQLITE_INTEGER: i32 = 1;
+pub const SQLITE_FLOAT: i32 = 2;
+pub const SQLITE_BLOB: i32 = 4;
+pub const SQLITE_NULL: i32 = 5;
+pub const SQLITE_TEXT: i32 = 3;
+pub const SQLITE_UTF8: i32 = 1;
+pub const SQLITE_UTF16LE: i32 = 2;
+pub const SQLITE_UTF16BE: i32 = 3;
+pub const SQLITE_UTF16: i32 = 4;
+pub const SQLITE_ANY: i32 = 5;

--- a/crates/sys/src/bindings/default/value.rs
+++ b/crates/sys/src/bindings/default/value.rs
@@ -1,0 +1,29 @@
+use core::ffi::{c_char, c_int, c_uchar, c_uint, c_void};
+
+use super::types::sqlite3_int64;
+
+/// A dynamically-typed [value object].
+///
+/// [value object]: https://sqlite.org/c3ref/value.html
+#[repr(C)]
+pub struct sqlite3_value {
+    _unused: [u8; 0],
+}
+
+unsafe extern "C" {
+    pub fn sqlite3_value_blob(value: *mut sqlite3_value) -> *const c_void;
+    pub fn sqlite3_value_double(value: *mut sqlite3_value) -> f64;
+    pub fn sqlite3_value_int(value: *mut sqlite3_value) -> c_int;
+    pub fn sqlite3_value_int64(value: *mut sqlite3_value) -> sqlite3_int64;
+    pub fn sqlite3_value_pointer(value: *mut sqlite3_value, arg2: *const c_char) -> *mut c_void;
+    pub fn sqlite3_value_text(value: *mut sqlite3_value) -> *const c_uchar;
+    pub fn sqlite3_value_bytes(value: *mut sqlite3_value) -> c_int;
+    pub fn sqlite3_value_type(value: *mut sqlite3_value) -> c_int;
+    pub fn sqlite3_value_numeric_type(value: *mut sqlite3_value) -> c_int;
+    pub fn sqlite3_value_nochange(value: *mut sqlite3_value) -> c_int;
+    pub fn sqlite3_value_frombind(value: *mut sqlite3_value) -> c_int;
+    pub fn sqlite3_value_encoding(value: *mut sqlite3_value) -> c_int;
+    pub fn sqlite3_value_subtype(value: *mut sqlite3_value) -> c_uint;
+    pub fn sqlite3_value_dup(value: *const sqlite3_value) -> *mut sqlite3_value;
+    pub fn sqlite3_value_free(value: *mut sqlite3_value);
+}

--- a/crates/sys/src/bindings/default/version.rs
+++ b/crates/sys/src/bindings/default/version.rs
@@ -1,0 +1,33 @@
+use core::ffi::{c_char, c_int};
+
+unsafe extern "C" {
+    /// The [version][] of the SQLite library, as a string.
+    ///
+    /// [version]: https://sqlite.org/c3ref/libversion.html
+    pub fn sqlite3_libversion() -> *const c_char;
+
+    /// The [version][] of the SQLite library, as a comparable integer.
+    ///
+    /// [version]: https://sqlite.org/c3ref/libversion.html
+    pub fn sqlite3_libversion_number() -> c_int;
+
+    /// The full [build version][] of the SQLite library.
+    ///
+    /// [version]: https://sqlite.org/c3ref/libversion.html
+    pub fn sqlite3_sourceid() -> *const c_char;
+
+    /// Check if a SQLite [compile-time option][] was used.
+    ///
+    /// [compile-time option]: https://sqlite.org/c3ref/compileoption_get.html
+    pub fn sqlite3_compileoption_used(zOptName: *const c_char) -> c_int;
+
+    /// Enumerate SQLite [compile-time options][] was used.
+    ///
+    /// [compile-time options]: https://sqlite.org/c3ref/compileoption_get.html
+    pub fn sqlite3_compileoption_get(n: c_int) -> *const c_char;
+
+    /// Check the compiled [thread-safety][] mode of SQLite.
+    ///
+    /// [thread-safety]: https://sqlite.org/c3ref/threadsafe.html
+    pub fn sqlite3_threadsafe() -> c_int;
+}

--- a/crates/sys/src/bindings/destructor.rs
+++ b/crates/sys/src/bindings/destructor.rs
@@ -1,0 +1,46 @@
+/// A destructor / memory `free` function for a value passed to SQLite as a
+/// [bound parameter][bind] or a [function result][].
+///
+/// A destructor can either be a `func`tion, or one of the [special values][]
+/// `SQLITE_STATIC` (`0`) or `SQLITE_TRANSIENT` (`-1`).
+///
+/// [bind]: https://sqlite.org/c3ref/bind_blob.html
+/// [function result]: https://sqlite.org/c3ref/result_blob.html
+/// [special values]: https://sqlite.org/c3ref/c_static.html
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union sqlite3_destructor_type {
+    pub func: unsafe extern "C" fn(context: *mut ::std::os::raw::c_void),
+    pub sentinel: isize,
+}
+
+unsafe impl Send for sqlite3_destructor_type {}
+unsafe impl Sync for sqlite3_destructor_type {}
+
+impl sqlite3_destructor_type {
+    /// Provide a custom [destructor](sqlite3_destructor_type) to SQLite.
+    pub const fn new(func: unsafe extern "C" fn(*mut ::std::os::raw::c_void)) -> Self {
+        sqlite3_destructor_type { func }
+    }
+
+    /// Construct `SQLITE_STATIC` or `SQLITE_TRANSIENT`.
+    pub(crate) const fn from_sentinel(sentinel: isize) -> Self {
+        sqlite3_destructor_type { sentinel }
+    }
+}
+
+impl ::core::fmt::Debug for sqlite3_destructor_type {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        // Safety: Both fields have the same size, so reading sentinel is always valid
+        let sentinel = unsafe { self.sentinel };
+        match sentinel {
+            0 => write!(f, "sqlite3_destructor_type::SQLITE_STATIC"),
+            -1 => write!(f, "sqlite3_destructor_type::SQLITE_TRANSIENT"),
+            _ => write!(
+                f,
+                "sqlite3_destructor_type::func({:p})",
+                sentinel as *const ()
+            ),
+        }
+    }
+}

--- a/crates/sys/src/bindings/mod.rs
+++ b/crates/sys/src/bindings/mod.rs
@@ -1,0 +1,10 @@
+#[cfg(feature = "bindgen")]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+#[cfg(not(feature = "bindgen"))]
+mod default;
+#[cfg(not(feature = "bindgen"))]
+pub(crate) mod destructor;
+
+#[cfg(not(feature = "bindgen"))]
+pub use default::*;

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -13,12 +13,7 @@
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 
-/// Generated `unsafe extern "C"` bindings from [bindgen][].
-///
-/// [bindgen]: https://rust-lang.github.io/rust-bindgen/
-mod bindings {
-    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-}
+mod bindings;
 
 pub use bindings::*;
 

--- a/src/column.rs
+++ b/src/column.rs
@@ -14,6 +14,30 @@ pub trait Columns<'r>: ColumnIndexes + Sized {
         'c: 'r;
 }
 
+impl<'r, T> ColumnIndexes for T
+where
+    T: Fetch<'r>,
+{
+    type Indexes = ();
+
+    #[inline(always)]
+    fn resolve<'c>(_statement: &Statement<'c>) -> Option<Self::Indexes> {
+        Some(())
+    }
+}
+
+impl<'r, T> Columns<'r> for T
+where
+    T: Fetch<'r>,
+{
+    fn fetch<'c>(statement: &'r Statement<'c>, _indexes: Self::Indexes) -> Result<Self>
+    where
+        'c: 'r,
+    {
+        <T as Fetch<'r>>::fetch(statement, ColumnIndex::INITIAL)
+    }
+}
+
 /// Implement [`Columns`] for a tuple type.
 macro_rules! tuple {
     ($i:ident: $t:ident) => {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -42,12 +42,6 @@ pub struct Connection {
 }
 
 impl Connection {
-    #[cfg(all(nightly, feature = "lang-iat"))]
-    type Builder<L = CString>
-        = ConnectionBuilder<L>
-    where
-        L: AsRef<CStr> + Clone + fmt::Debug;
-
     #[inline]
     #[must_use]
     fn new(inner: ffi::Connection) -> Self {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -14,6 +14,29 @@ use crate::{
     statement::{PrepareOptions, Statement},
 };
 
+/// A _connection_ to one or more open SQLite database(s).
+///
+/// Use `Connection` to [prepare](Self::prepare) and [execute](Self::execute)
+/// SQL statements. A `Connection` will remain open until [closed](Self::close)
+/// or [dropped](core::ops::Drop).
+///
+/// (Even though SQLite is a local database, without a network or socket
+/// connection to a remote server, SQLite still uses the term “connection”.)
+///
+/// # Examples
+///
+/// ```rust
+/// use squire::{Connection, Database};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let connection = Connection::open(Database::memory())?;
+///
+/// let mut statement = connection.prepare("SELECT sqlite_version();")?;
+/// let version: String = statement.query(())?.one()?;
+#[doc = concat!("assert_eq!(\"", env!("SQUIRE_SQLITE_VERSION"), "\", version);")]
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug)]
 pub struct Connection {
     inner: ffi::Connection,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -37,7 +37,6 @@ use crate::{
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct Connection {
     inner: ffi::Connection,
 }
@@ -111,6 +110,12 @@ impl Connection {
 impl ffi::Connected for Connection {
     fn as_connection_ptr(&self) -> *mut sqlite::sqlite3 {
         self.internal_ref().as_ptr()
+    }
+}
+
+impl fmt::Debug for Connection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Connection({:p})", self.internal_ref().as_ptr())
     }
 }
 

--- a/src/error/category.rs
+++ b/src/error/category.rs
@@ -148,6 +148,14 @@ pub enum ErrorCategory {
     ///
     /// [result codes]: https://sqlite.org/rescode.html
     Parameter = super::code::SQUIRE_ERROR_PARAMETER,
+
+    /// A column value stored in SQLite could not be read into a Rust type.
+    ///
+    /// (This [error category](ErrorCategory) is defined by Squire; not SQLite.
+    /// No SQLite [result codes][] correspond to `ErrorCategory::Row`.)
+    ///
+    /// [result codes]: https://sqlite.org/rescode.html
+    Row = super::code::SQUIRE_ERROR_ROW,
 }
 
 impl ErrorCategory {
@@ -190,6 +198,7 @@ impl ErrorCategory {
             sqlite::SQLITE_NOTADB => Some(Self::InvalidDatabase),
             super::code::SQUIRE_ERROR_FETCH => Some(Self::Fetch),
             super::code::SQUIRE_ERROR_PARAMETER => Some(Self::Parameter),
+            super::code::SQUIRE_ERROR_ROW => Some(Self::Row),
             _ => None,
         }
     }

--- a/src/error/category.rs
+++ b/src/error/category.rs
@@ -135,7 +135,7 @@ pub enum ErrorCategory {
     /// A column value stored in SQLite could not be read into a Rust type.
     ///
     /// (This [error category](ErrorCategory) is defined by Squire; not SQLite.
-    /// No SQLite [result codes][] correspond to `ErrorCategory::Parameter`.)
+    /// No SQLite [result codes][] correspond to `ErrorCategory::Fetch`.)
     ///
     /// [result codes]: https://sqlite.org/rescode.html
     Fetch = super::code::SQUIRE_ERROR_FETCH,

--- a/src/error/code.rs
+++ b/src/error/code.rs
@@ -372,3 +372,11 @@ impl fmt::Display for ErrorCode {
         }
     }
 }
+
+pub(super) struct ErrorCodeName(pub(super) ErrorCode);
+
+impl fmt::Debug for ErrorCodeName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}

--- a/src/error/code.rs
+++ b/src/error/code.rs
@@ -29,6 +29,8 @@ pub(crate) const SQUIRE_ERROR_PARAMETER_BIND: i32 = code!(2, 1);
 pub(crate) const SQUIRE_ERROR_PARAMETER_RANGE: i32 = code!(2, 2);
 pub(crate) const SQUIRE_ERROR_PARAMETER_RESOLVE: i32 = code!(2, 3);
 pub(crate) const SQUIRE_ERROR_PARAMETER_INVALID_INDEX: i32 = code!(2, 4);
+pub(crate) const SQUIRE_ERROR_ROW: i32 = code!(3);
+pub(crate) const SQUIRE_ERROR_ROW_NOT_RETURNED: i32 = code!(3, 1);
 
 impl ErrorCode {
     /// Wrap a return value from SQLite in an [`ErrorCode`].
@@ -205,6 +207,8 @@ impl ErrorCode {
             Self::SQUIRE_PARAMETER_BIND => Some("SQUIRE_ERROR_PARAMETER_BIND"),
             Self::SQUIRE_PARAMETER_RANGE => Some("SQUIRE_ERROR_PARAMETER_RANGE"),
             Self::SQUIRE_PARAMETER_RESOLVE => Some("SQUIRE_ERROR_PARAMETER_RESOLVE"),
+            Self::SQUIRE_ROW => Some("SQUIRE_ERROR_ROW"),
+            Self::SQUIRE_ROW_NOT_RETURNED => Some("SQUIRE_ERROR_ROW_NOT_RETURNED"),
 
             // Unrecognized code
             _ => None,
@@ -222,6 +226,8 @@ impl ErrorCode {
             Self::SQUIRE_PARAMETER_RANGE => "parameter value out of range",
             Self::SQUIRE_PARAMETER_RESOLVE => "error resolving parameter index",
             Self::SQUIRE_PARAMETER_INVALID_INDEX => "parameter index must be > 0",
+            Self::SQUIRE_ROW => "error retrieving selected row",
+            Self::SQUIRE_ROW_NOT_RETURNED => "query returned no rows",
 
             _ => {
                 let ptr = unsafe { sqlite3_errstr(self.raw()) };
@@ -348,6 +354,8 @@ impl ErrorCode {
     pub(crate) const SQUIRE_PARAMETER_RESOLVE: Self = Self::define(SQUIRE_ERROR_PARAMETER_RESOLVE);
     pub(crate) const SQUIRE_PARAMETER_INVALID_INDEX: Self =
         Self::define(SQUIRE_ERROR_PARAMETER_INVALID_INDEX);
+    pub(crate) const SQUIRE_ROW: Self = Self::define(SQUIRE_ERROR_ROW);
+    pub(crate) const SQUIRE_ROW_NOT_RETURNED: Self = Self::define(SQUIRE_ERROR_ROW_NOT_RETURNED);
 }
 
 impl Default for ErrorCode {

--- a/src/error/location.rs
+++ b/src/error/location.rs
@@ -8,7 +8,7 @@ use sqlite::sqlite3_error_offset;
 /// The offset within an SQL source input of an [`Error`](crate::Error).
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 #[cfg_attr(
-    feature = "lang-rustc-scalar-valid-range",
+    all(nightly, feature = "lang-rustc-scalar-valid-range"),
     rustc_layout_scalar_valid_range_start(0)
 )]
 pub struct ErrorLocation(i32);
@@ -17,11 +17,11 @@ impl ErrorLocation {
     #[cfg(sqlite_has_error_offset)]
     const fn new(location: c_int) -> Option<Self> {
         if location >= 0 {
-            #[cfg(feature = "lang-rustc-scalar-valid-range")]
+            #[cfg(all(nightly, feature = "lang-rustc-scalar-valid-range"))]
             {
                 Some(unsafe { Self(location as i32) })
             }
-            #[cfg(not(feature = "lang-rustc-scalar-valid-range"))]
+            #[cfg(not(all(nightly, feature = "lang-rustc-scalar-valid-range")))]
             {
                 Some(Self(location as i32))
             }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -106,6 +106,12 @@ impl Error {
         Self::with_detail(ErrorCode::SQUIRE_FETCH_PARSE, source.into())
     }
 
+    #[cold]
+    #[inline(never)]
+    pub(crate) fn row_not_returned() -> Self {
+        Self::new(ErrorCode::SQUIRE_ROW_NOT_RETURNED)
+    }
+
     /// The [`ErrorCode`] identifying what error occurred.
     pub const fn code(&self) -> ErrorCode {
         self.inner.code

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -34,7 +34,7 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 /// as parameters and [fetched](crate::Fetch) from column values).
 ///
 /// [return codes]: https://sqlite.org/rescode.html
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Error {
     inner: Box<ErrorInner>,
 }
@@ -178,6 +178,27 @@ impl Error {
 impl Default for Error {
     fn default() -> Self {
         Self::new(ErrorCode::default())
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let code = self::code::ErrorCodeName(self.code());
+        let message = self.message().unwrap_or_else(|| self.code().description());
+
+        let mut tuple = f.debug_tuple("Error");
+
+        tuple.field(&code);
+        tuple.field(&message);
+
+        if let Some(location) = self.source_location() {
+            tuple.field(&location);
+        }
+        if let Some(integration) = self.as_integration() {
+            tuple.field(&integration);
+        }
+
+        tuple.finish()
     }
 }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -92,14 +92,14 @@ impl Error {
         })
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code, unreachable_code)]
     #[cold]
     #[inline(never)]
     pub(crate) fn from_bind(source: impl Into<IntegrationError>) -> Self {
         Self::with_detail(ErrorCode::SQUIRE_PARAMETER_BIND, source.into())
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code, unreachable_code)]
     #[cold]
     #[inline(never)]
     pub(crate) fn from_fetch(source: impl Into<IntegrationError>) -> Self {
@@ -318,6 +318,7 @@ impl<E> From<E> for ErrorDetail
 where
     IntegrationError: From<E>,
 {
+    #[allow(unreachable_code)]
     fn from(error: E) -> Self {
         Self::Integration(error.into())
     }

--- a/src/error/reason.rs
+++ b/src/error/reason.rs
@@ -49,6 +49,14 @@ pub enum ErrorReason {
     ///
     /// [result codes]: https://sqlite.org/rescode.html
     Parameter(ParameterError),
+
+    /// Extended [`ErrorCategory::Row`] error codes.
+    ///
+    /// (This [error code](ErrorReason) is defined by Squire; not SQLite.
+    /// No SQLite [result codes][] correspond to `ErrorReason::Row`.)
+    ///
+    /// [result codes]: https://sqlite.org/rescode.html
+    Row(RowError),
 }
 
 impl ErrorReason {
@@ -68,6 +76,7 @@ impl ErrorReason {
 
             ErrorReason::Fetch(_) => ErrorCategory::Fetch,
             ErrorReason::Parameter(_) => ErrorCategory::Parameter,
+            ErrorReason::Row(_) => ErrorCategory::Parameter,
         }
     }
 
@@ -87,6 +96,7 @@ impl ErrorReason {
 
             Self::Fetch(err) => err as i32,
             Self::Parameter(err) => err as i32,
+            Self::Row(err) => err as i32,
         };
 
         unsafe { ErrorCode::new_unchecked(code) }
@@ -212,6 +222,7 @@ impl ErrorReason {
             super::code::SQUIRE_ERROR_PARAMETER_INVALID_INDEX => {
                 Some(Self::Parameter(ParameterError::InvalidIndex))
             }
+            super::code::SQUIRE_ERROR_ROW_NOT_RETURNED => Some(Self::Row(RowError::NotReturned)),
 
             _ => None,
         }
@@ -627,4 +638,17 @@ pub enum ParameterError {
     /// Creating a [`BindIndex`](crate::BindIndex) failed because the input
     /// value was zero or negative.
     InvalidIndex = super::code::SQUIRE_ERROR_PARAMETER_INVALID_INDEX,
+}
+
+/// An error retrieving a row from SQLite.
+///
+/// (This [error category](ErrorCategory) is defined by Squire; not SQLite.
+/// No SQLite [result codes][] correspond to `RowError`.)
+///
+/// [result codes]: https://sqlite.org/rescode.html
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[repr(i32)]
+pub enum RowError {
+    /// The query didn't return a row.
+    NotReturned = super::code::SQUIRE_ERROR_ROW_NOT_RETURNED,
 }

--- a/src/error/reason.rs
+++ b/src/error/reason.rs
@@ -34,15 +34,15 @@ pub enum ErrorReason {
     /// Extended read-only error codes.
     ReadOnly(ReadOnlyError),
 
-    /// Extended [`ErrorReason::Fetch`] error codes.
+    /// Extended [`ErrorCategory::Fetch`] error codes.
     ///
     /// (This [error code](ErrorReason) is defined by Squire; not SQLite.
-    /// No SQLite [result codes][] correspond to `ErrorReason::Parameter`.)
+    /// No SQLite [result codes][] correspond to `ErrorReason::Fetch`.)
     ///
     /// [result codes]: https://sqlite.org/rescode.html
     Fetch(FetchError),
 
-    /// Extended [`ErrorReason::Parameter`] error codes.
+    /// Extended [`ErrorCategory::Parameter`] error codes.
     ///
     /// (This [error code](ErrorReason) is defined by Squire; not SQLite.
     /// No SQLite [result codes][] correspond to `ErrorReason::Parameter`.)
@@ -110,8 +110,8 @@ impl ErrorReason {
     /// Find the [`ErrorReason`] for a SQLite [result code][].
     ///
     /// [result code]: https://sqlite.org/rescode.html
-    #[allow(deprecated)]
     pub const fn from_raw_code(code: i32) -> Option<Self> {
+        #[allow(deprecated)]
         match code {
             // Abort errors
             sqlite::SQLITE_ABORT_ROLLBACK => Some(Self::Aborted(AbortError::Rollback)),

--- a/src/ffi/connection.rs
+++ b/src/ffi/connection.rs
@@ -1,4 +1,4 @@
-use core::{ffi::CStr, ptr};
+use core::{ffi::CStr, fmt, ptr};
 
 use sqlite::{SQLITE_OK, SQLITE_OPEN_EXRESCODE, sqlite3, sqlite3_close, sqlite3_open_v2};
 
@@ -8,7 +8,6 @@ use super::mutex::MutexRef;
 use crate::error::{Error, Result};
 
 /// A thin wrapper around a [`sqlite3`] connection pointer.
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct Connection {
     handle: ptr::NonNull<sqlite3>,
@@ -77,6 +76,12 @@ impl Connection {
     #[inline]
     pub const fn as_ptr(&self) -> *mut sqlite3 {
         self.handle.as_ptr()
+    }
+}
+
+impl fmt::Debug for Connection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Connection({:p})", self.handle)
     }
 }
 

--- a/src/ffi/statement.rs
+++ b/src/ffi/statement.rs
@@ -1,5 +1,6 @@
 use core::{
     ffi::{CStr, c_char, c_int},
+    fmt,
     marker::PhantomData,
     ptr,
 };
@@ -27,7 +28,6 @@ use crate::{
 };
 
 /// A thin wrapper around a [`sqlite3_stmt`] prepared statement pointer.
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct Statement<'c> {
     handle: ptr::NonNull<sqlite3_stmt>,
@@ -338,6 +338,12 @@ where
     #[inline]
     unsafe fn reset(&mut self) -> Result<()> {
         call! { sqlite3_reset(self.as_statement_ptr()) }
+    }
+}
+
+impl fmt::Debug for Statement<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Statement({:p})", self.handle)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@
     all(nightly, feature = "lang-array-assume-init"),
     feature(maybe_uninit_array_assume_init)
 )]
-#![cfg_attr(all(nightly, feature = "lang-iat"), feature(inherent_associated_types))]
 #![cfg_attr(
     all(nightly, feature = "lang-rustc-scalar-valid-range"),
     allow(internal_features)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! Squire provides an idiomatic and performant Rust interface for [SQLite][].
 //!
-//! ```rust
+#![cfg_attr(feature = "derive", doc = "```rust")]
+#![cfg_attr(not(feature = "derive"), doc = "```ignore")]
 //! # #![cfg_attr(
 //! #     all(nightly, feature = "lang-array-assume-init"),
 //! #     feature(maybe_uninit_array_assume_init)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 //! Squire provides an idiomatic and performant Rust interface for [SQLite][].
 //!
 //! ```rust
+//! # #![cfg_attr(
+//! #     all(nightly, feature = "lang-array-assume-init"),
+//! #     feature(maybe_uninit_array_assume_init)
+//! # )]
 //! use squire::{Columns, Connection, Database};
 //!
 //! #[derive(Columns, PartialEq, Eq, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,17 @@
 #![cfg_attr(
-    feature = "lang-array-assume-init",
+    all(nightly, feature = "lang-array-assume-init"),
     feature(maybe_uninit_array_assume_init)
 )]
-#![cfg_attr(feature = "lang-iat", feature(inherent_associated_types))]
-#![cfg_attr(feature = "lang-rustc-scalar-valid-range", allow(internal_features))]
-#![cfg_attr(feature = "lang-rustc-scalar-valid-range", feature(rustc_attrs))]
-#![cfg_attr(feature = "lang-step-trait", feature(step_trait))]
+#![cfg_attr(all(nightly, feature = "lang-iat"), feature(inherent_associated_types))]
+#![cfg_attr(
+    all(nightly, feature = "lang-rustc-scalar-valid-range"),
+    allow(internal_features)
+)]
+#![cfg_attr(
+    all(nightly, feature = "lang-rustc-scalar-valid-range"),
+    feature(rustc_attrs)
+)]
+#![cfg_attr(all(nightly, feature = "lang-step-trait"), feature(step_trait))]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 
 mod bind;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,48 @@
+//! Squire provides an idiomatic and performant Rust interface for [SQLite][].
+//!
+//! ```rust
+//! use squire::{Columns, Connection, Database};
+//!
+//! #[derive(Columns, PartialEq, Eq, Clone, Debug)]
+//! struct User {
+//!     id: u64,
+//!     username: String,
+//!     email: Option<String>,
+//! }
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let connection = Connection::open(Database::memory())?;
+//!
+//! connection.execute(
+//!     "CREATE TABLE users (
+//!         id INTEGER PRIMARY KEY,
+//!         username TEXT NOT NULL,
+//!         email TEXT
+//!      ) STRICT",
+//!      (), // no parameters
+//! )?;
+//!
+//! let mut add_user = connection.prepare("INSERT INTO users (username, email) VALUES (?, ?)")?;
+//!
+//! add_user.execute(("alice", "alice@example.com"))?;
+//! add_user.execute(("bob", None::<&str>))?;
+//!
+//! let mut select_users = connection.prepare("SELECT * FROM users")?;
+//! let users: Vec<User> = select_users.query(())?.all()?;
+//!
+//! assert_eq!(
+//!     users,
+//!     vec![
+//!         User { id: 1, username: "alice".to_owned(), email: Some("alice@example.com".to_owned()) },
+//!         User { id: 2, username: "bob".to_owned(), email: None },
+//!     ],
+//! );
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [SQLite]: https://sqlite.org/
+
 #![cfg_attr(
     all(nightly, feature = "lang-array-assume-init"),
     feature(maybe_uninit_array_assume_init)

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -3,7 +3,7 @@ use sqlite::{SQLITE_PREPARE_NO_VTAB, SQLITE_PREPARE_PERSISTENT, sqlite3};
 
 use crate::{
     bind::Bind,
-    column::ColumnIndexes,
+    column::{ColumnIndexes, Columns},
     connection::Connection,
     error::{Error, ErrorCode, Result},
     ffi,
@@ -374,6 +374,17 @@ where
         C: ColumnIndexes,
     {
         Rows::new(self)
+    }
+
+    pub fn one<C>(self) -> Result<C>
+    where
+        C: for<'r> Columns<'r>,
+    {
+        match Rows::new(self)?.next() {
+            Ok(Some(row)) => Ok(row),
+            Ok(None) => Err(Error::row_not_returned()),
+            Err(err) => Err(err),
+        }
     }
 
     pub fn run(self) -> Result<isize> {

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -1,4 +1,4 @@
-use core::{ffi::c_int, marker::PhantomData, mem};
+use core::{ffi::c_int, fmt, marker::PhantomData, mem};
 use sqlite::{SQLITE_PREPARE_NO_VTAB, SQLITE_PREPARE_PERSISTENT, sqlite3};
 
 use crate::{
@@ -16,7 +16,6 @@ use crate::{
 /// ready to [bind](Self::bind()) and [execute](Execution).
 ///
 /// [prepared statement]: https://sqlite.org/c3ref/stmt.html
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct Statement<'c> {
     inner: ffi::Statement<'c>,
@@ -134,7 +133,13 @@ impl<'c, 's> ffi::Connected for &'s mut Statement<'c> {
     }
 }
 
-impl<'c> Drop for Statement<'c> {
+impl fmt::Debug for Statement<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Statement({:p})", self.internal_ref().as_ptr())
+    }
+}
+
+impl Drop for Statement<'_> {
     fn drop(&mut self) {
         let _ = unsafe { self.internal_mut().finalize() };
     }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -381,6 +381,14 @@ where
         Rows::new(self)
     }
 
+    pub fn all<T, C>(self) -> Result<T>
+    where
+        T: FromIterator<C>,
+        C: for<'r> Columns<'r> + 'static,
+    {
+        self.rows()?.into_iter().collect()
+    }
+
     pub fn one<C>(self) -> Result<C>
     where
         C: for<'r> Columns<'r>,

--- a/src/types/bind.rs
+++ b/src/types/bind.rs
@@ -157,7 +157,7 @@ fn invalid_index() -> Error {
     ErrorReason::Parameter(ParameterError::InvalidIndex).into()
 }
 
-#[cfg(feature = "lang-step-trait")]
+#[cfg(all(nightly, feature = "lang-step-trait"))]
 impl core::iter::Step for BindIndex {
     fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
         if start.0.get() <= end.0.get() {

--- a/src/types/column.rs
+++ b/src/types/column.rs
@@ -152,7 +152,7 @@ fn invalid_index() -> Error {
     ErrorCategory::Range.into()
 }
 
-#[cfg(feature = "lang-step-trait")]
+#[cfg(all(nightly, feature = "lang-step-trait"))]
 impl core::iter::Step for ColumnIndex {
     fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
         if start.0 <= end.0 {

--- a/tests/columns.rs
+++ b/tests/columns.rs
@@ -48,6 +48,29 @@ fn fetch_named_struct() -> Result {
 }
 
 #[derive(Columns)]
+struct IdentifiedRow {
+    id: i64,
+    a: String,
+    b: i64,
+    c: f64,
+}
+
+#[test]
+fn fetch_named_struct_wildcard() -> Result {
+    let connection = setup()?;
+
+    let mut query = connection.prepare("SELECT * FROM example WHERE id = 1;")?;
+    let row: IdentifiedRow = query.query(())?.one()?;
+
+    assert_eq!(1, row.id);
+    assert_eq!("hello 🌎!", row.a);
+    assert_eq!(42, row.b);
+    assert_eq!(3.14, row.c);
+
+    Ok(())
+}
+
+#[derive(Columns)]
 struct BorrowedRow<'a> {
     #[squire(borrow)]
     a: &'a str,

--- a/tests/columns.rs
+++ b/tests/columns.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(
-    feature = "lang-array-assume-init",
+    all(nightly, feature = "lang-array-assume-init"),
     feature(maybe_uninit_array_assume_init)
 )]
 #![allow(clippy::approx_constant)]

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(
-    feature = "lang-array-assume-init",
+    all(nightly, feature = "lang-array-assume-init"),
     feature(maybe_uninit_array_assume_init)
 )]
 

--- a/tests/parameters.rs
+++ b/tests/parameters.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(
-    feature = "lang-array-assume-init",
+    all(nightly, feature = "lang-array-assume-init"),
     feature(maybe_uninit_array_assume_init)
 )]
 #![allow(clippy::approx_constant)]


### PR DESCRIPTION
- Remove `linked` and `single-thread` features; fixes building with `--all-features`
- Add `Execution::all` and `Execution::one` to simplify common queries
- Implement `Columns` for all `Fetch`able types; lets single-column results be queried without a tuple
- Fix a bug in the `derive` macros for `Columns` and `Parameters` where named columns/parameters would be mapped incorrectly
- Improve doc comments
- Improve `Debug` format of `Connection`, `Statement`, and `Error`