### PR TITLE
Bundle SQLite 3.53.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "squire-sqlite3-src"
-version = "3.51.0-alpha.2"
+version = "3.53.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81494723359a518f52c0dfab12bab2e8af7d02875d9013b9448e97199a0db576"
+checksum = "ed006d7ee728570122c705908bfc735bdcd35bdddc16b2e036abc6a9f2db4d37"
 dependencies = [
  "cc",
  "strum",

--- a/crates/features/src/lib.rs
+++ b/crates/features/src/lib.rs
@@ -58,6 +58,7 @@ pub use version::Version;
 /// A fully-[feature probed](Probe) SQLite library.
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[derive(Clone, Debug)]
 pub struct Library {
     version: Version,
     threading: Threading,
@@ -125,13 +126,13 @@ impl Library {
         // Register all possible feature configs
         for key in FeatureKey::all() {
             let name = key.as_str();
-            println!("cargo:rustc-check-cfg=cfg(sqlite_has_{name})");
+            println!("cargo::rustc-check-cfg=cfg(sqlite_has_{name})");
         }
 
         // Enable configs for supported features
         for key in &self.features {
             let name = key.as_str();
-            println!("cargo:rustc-cfg=sqlite_has_{name}");
+            println!("cargo::rustc-cfg=sqlite_has_{name}");
         }
 
         // Include SQLite library version

--- a/crates/features/src/probe/build/compile.rs
+++ b/crates/features/src/probe/build/compile.rs
@@ -131,6 +131,10 @@ pub(super) fn run_probe(build: Build) -> Library {
     // Link to SQLite
     cmd.arg(format!("-l{}", build.lib_name));
 
+    // Link libm on non-Windows (FTS5 uses log(), which is separate on Linux)
+    #[cfg(not(target_os = "windows"))]
+    cmd.arg("-lm");
+
     // Set output
     let probe_exe = out_dir.join("sqlite_probe");
     cmd.arg("-o").arg(&probe_exe);

--- a/crates/sys/Cargo.toml
+++ b/crates/sys/Cargo.toml
@@ -90,7 +90,7 @@ wal = []
 [build-dependencies.sqlite]
 package = "squire-sqlite3-src"
 # path = "../../../ext/squire-src"
-version = "3.51.0-alpha.2"
+version = "3.53.0-alpha.1"
 optional = true
 
 [build-dependencies.bindgen]

--- a/crates/sys/build.rs
+++ b/crates/sys/build.rs
@@ -11,14 +11,11 @@ fn main() -> Result {
     #[cfg(any(feature = "bindgen", feature = "bundled"))]
     let dest = out_path();
 
-    #[cfg(all(not(feature = "bindgen"), feature = "bundled"))]
-    build_bundled_sqlite(&dest)?;
+    #[cfg(feature = "bundled")]
+    let build = build_bundled_sqlite(&dest)?;
 
     #[cfg(all(feature = "bindgen", feature = "bundled"))]
-    let header_path = {
-        let build = build_bundled_sqlite(&dest)?;
-        build.header()
-    };
+    let header_path = build.header();
     #[cfg(all(feature = "bindgen", not(feature = "bundled")))]
     let header_path = PathBuf::from("wrapper.h");
 
@@ -35,41 +32,20 @@ fn main() -> Result {
 
     // Detect features and emit metadata
     #[cfg(feature = "bundled")]
-    let library = features::Library::new(
-        features::Version::new(3, 51, 0), // Update this when bundled version changes
-        threading_mode(),
-        bundled_features(),
+    let probe = features::build::Library::probe(
+        features::build::Build::default()
+            .include_path(build.header().parent().expect("INCLUDE"))
+            .link_path(&dest),
     );
     #[cfg(not(feature = "bundled"))]
-    let library = {
-        use features::build;
-        let probe = build::Library::probe(build::Build::default());
-        features::Library::probe(&probe)
-    };
+    let probe = features::build::Library::probe(features::build::Build::default());
+
+    let library = features::Library::probe(&probe);
 
     library.emit_cargo_metadata();
     library.emit_cfg();
 
     Ok(())
-}
-
-#[cfg(feature = "bundled")]
-fn threading_mode() -> features::Threading {
-    #[cfg(feature = "serialized")]
-    return features::Threading::Serialized;
-    #[cfg(all(feature = "multi-thread", not(feature = "serialized")))]
-    return features::Threading::MultiThread;
-    #[cfg(not(feature = "multi-thread"))]
-    return features::Threading::SingleThread;
-}
-
-#[cfg(feature = "bundled")]
-fn bundled_features() -> impl Iterator<Item = features::FeatureKey> {
-    use features::FeatureKey::*;
-
-    let all = [(Json, cfg!(feature = "json")), (PrepareQuiet, true)];
-    all.into_iter()
-        .filter_map(|(key, enabled)| if enabled { Some(key) } else { None })
 }
 
 #[cfg(any(feature = "bindgen", feature = "bundled"))]

--- a/crates/sys/build.rs
+++ b/crates/sys/build.rs
@@ -292,13 +292,12 @@ fn generate_bindings(header: &Path, dest: &Path) -> Result {
                                 if let Some(param_name) = param_names.get(i) {
                                     let ident =
                                         syn::Ident::new(param_name, proc_macro2::Span::call_site());
-                                    pat_type.pat = Box::new(syn::parse_quote! { #ident });
+                                    *pat_type.pat = syn::parse_quote! { #ident };
                                 }
 
                                 // Replace the destructor parameter type
                                 if i == *param_index {
-                                    pat_type.ty =
-                                        Box::new(syn::parse_quote! { sqlite3_destructor_type });
+                                    *pat_type.ty = syn::parse_quote! { sqlite3_destructor_type };
                                 }
                             }
                         }

--- a/src/ffi/string.rs
+++ b/src/ffi/string.rs
@@ -401,7 +401,7 @@ impl fmt::Write for StringBuilder {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         // SAFETY: `sqlite3_str_append` is safe to call with any valid
         // `sqlite3_str` pointer. The length must be non-negative.
-        debug_assert!(s.len() <= c_int::MAX as usize);
+        debug_assert!(self.len() + s.len() <= c_int::MAX as usize);
         unsafe {
             sqlite3_str_append(self.as_ptr(), s.as_ptr() as *const c_char, s.len() as c_int);
         }

--- a/src/types/bind.rs
+++ b/src/types/bind.rs
@@ -23,7 +23,7 @@ impl BindIndex {
 
     pub const fn new(value: c_int) -> Option<Self> {
         match NonZero::new(value) {
-            Some(index) if value > 0 => Some(Self(index)),
+            Some(index) => Some(Self(index)),
             _ => None,
         }
     }


### PR DESCRIPTION
Bundle the [SQLite 3.53.0](https://sqlite.org/releaselog/3_53_0.html) release; update `squire-sqlite3-src` to `v3.53.0-alpha.1`.

- silverlyra/squire-src#5
- Fix version and feature detection of bundled SQLite
- Fix conditional compilation based on detected features
- Fix probing SQLite when `fts5` is included